### PR TITLE
SEO-187452-php-gantt-Title-too-long/short

### DIFF
--- a/PHP/Gantt/Overview.md
+++ b/PHP/Gantt/Overview.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Overview
-description: overview
+title: Overview of PHP Gantt control | Syncfusion
+description: Learn here about overview support in Syncfusion Essential  PHP Gantt control, its elements and more details.
 platform: php
 control: Gantt
 documentation: ug
 ---
 
-# Overview
+# Overview of PHP Gantt control
 
 The Essential PHP Gantt control is designed to visualize and edit the project schedule, and track the project progress. It helps to organize and schedule the projects and also you can update the project schedule through interactions like editing, dragging and resizing.
 

--- a/PHP/Gantt/Overview.md
+++ b/PHP/Gantt/Overview.md
@@ -1,13 +1,13 @@
 ---
 layout: post
 title: Overview of PHP Gantt control | Syncfusion
-description: Learn here about overview support in Syncfusion Essential  PHP Gantt control, its elements and more details.
+description: Learn here about overview support in Syncfusion Essential PHP Gantt control, its elements and more details.
 platform: php
 control: Gantt
 documentation: ug
 ---
 
-# Overview of PHP Gantt control
+# Overview of PHP Gantt Control
 
 The Essential PHP Gantt control is designed to visualize and edit the project schedule, and track the project progress. It helps to organize and schedule the projects and also you can update the project schedule through interactions like editing, dragging and resizing.
 


### PR DESCRIPTION
Hi @Yvone-Atieno,

|Title|Description|
|--|--|
|Category|Title too long/short link |
|Hotfix|https://github.com/syncfusion-content/php-docs/pull/311|
|Task||
|Content Ticket||
|UX Ticket||

|Changes made|Reason for changes|
|--|--|
|Modify meta elements|For meta alignment with proper character count|

Regards,
Edith.