### PR TITLE
SEO-206704-Php-H1-tag-Missing-hotfix 

### DIFF
--- a/PHP/ListView/Getting-Started.md
+++ b/PHP/ListView/Getting-Started.md
@@ -7,7 +7,7 @@ control: ListView
 documentation: ug
 ---
 
-## Getting Started
+# Getting Started
 
 The **Essential PHP ListView** widget builds an interactive list view interface. This control allows you to select an item from a list-like interface and provides the infrastructure to display a set of data items in different layouts or views. Lists display data, data navigation, result lists, and data entry.
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |H1 Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/206704|
|Share point | [Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BC1479F0A-9619-4A7C-B47E-C05E2DB08DD9%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it. |





Regards, 
Asha